### PR TITLE
Add WebSocket streaming endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 ## 1 Edits, Added API Server
 
+### WebSocket Streaming API
+
+The FastAPI server exposes a WebSocket endpoint for real-time audio generation.
+
+1. Connect to `ws://<host>:<port>/api/generate/ws`.
+2. Send a JSON payload:
+   ```json
+   {
+     "script": "Speaker 0: Hello!",
+     "speaker_voices": ["en-Alice_woman"],
+     "cfg_scale": 1.3
+   }
+   ```
+3. The server streams back binary messages containing 16-bit PCM audio at 24000 Hz.
+
+Close the socket to stop generation; the server will clean up on disconnect.
+
 ## 🎙️ VibeVoice: A Frontier Long Conversational Text-to-Speech Model
 [![Project Page](https://img.shields.io/badge/Project-Page-blue?logo=microsoft)](https://microsoft.github.io/VibeVoice)
 [![Hugging Face](https://img.shields.io/badge/HuggingFace-Collection-orange?logo=huggingface)](https://huggingface.co/collections/microsoft/vibevoice-68a2ef24a875c44be47b034f)

--- a/api/main.py
+++ b/api/main.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import numpy as np
 import soundfile as sf
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse, Response
 from pydantic import BaseModel, Field
 from typing import List
@@ -48,6 +48,43 @@ class HealthCheckResponse(BaseModel):
 concurrency_limiter = asyncio.Semaphore(1)
 
 # --- API Endpoints ---
+
+@app.websocket("/api/generate/ws")
+async def generate_ws(
+    websocket: WebSocket,
+    tts_service: TTSService = Depends(get_tts_service)
+):
+    """Generate audio over a WebSocket connection.
+
+    The client must send a JSON message with ``script`` (str), ``speaker_voices``
+    (list[str]) and optional ``cfg_scale`` (float). Binary audio chunks encoded as
+    16-bit PCM at 24000Hz are streamed back over the socket.
+    """
+    await websocket.accept()
+    try:
+        data = await websocket.receive_json()
+        script = data["script"]
+        speaker_voices = data["speaker_voices"]
+        cfg_scale = data.get("cfg_scale", 1.3)
+        async with concurrency_limiter:
+            audio_generator = tts_service.generate_stream_async(
+                script=script,
+                speaker_voices=speaker_voices,
+                cfg_scale=cfg_scale
+            )
+            try:
+                async for chunk in audio_generator:
+                    await websocket.send_bytes(chunk)
+            finally:
+                await audio_generator.aclose()
+        await websocket.close()
+    except WebSocketDisconnect:
+        print("WebSocket disconnected")
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        await websocket.close(code=1011)
+
 @app.post("/api/generate/streaming", tags=["Generation"])
 async def generate_streaming(
     request: TTSRequest,


### PR DESCRIPTION
## Summary
- stream PCM audio over new `/api/generate/ws` WebSocket endpoint
- document WebSocket protocol and usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b87c5d8734832a84be8a230ed67741